### PR TITLE
[feat] make twisted an extra requirement

### DIFF
--- a/pkg/requirements.pip
+++ b/pkg/requirements.pip
@@ -1,11 +1,7 @@
 jsonschema  #<=0.8 -- are we done with this conflict?
 dirspec
 pyopenssl
-# needed for propper hostname identification, see http://twistedmatrix.com/documents/current/core/howto/ssl.html
-service_identity
 python-dateutil
-Twisted>=12.1
-zope.interface
 pyzmq
 txzmq
 

--- a/setup.py
+++ b/setup.py
@@ -138,4 +138,11 @@ setup(
     tests_require=tests_requirements,
     include_package_data=True,
     zip_safe=False,
+
+    extras_require={
+        # needed for leap.common.http
+        #  service_identity needed for propper hostname identification,
+        #  see http://twistedmatrix.com/documents/current/core/howto/ssl.html
+        'Twisted':  ["Twisted>=14.0.2", "service_identity", "zope.insterface"]
+    },
 )

--- a/src/leap/common/http.py
+++ b/src/leap/common/http.py
@@ -18,6 +18,18 @@
 Twisted HTTP/HTTPS client.
 """
 
+try:
+    import twisted
+except ImportError:
+    print "*******"
+    print "Twisted is needed to use leap.common.http module"
+    print ""
+    print "Install the extra requirement of the package:"
+    print "$ pip install leap.common[Twisted]"
+    import sys
+    sys.exit(1)
+
+
 from leap.common.certs import get_compatible_ssl_context_factory
 
 from zope.interface import implements


### PR DESCRIPTION
We don't want to depend on twisted for other things than
leap.common.http.
